### PR TITLE
Implement simple waveform analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# auto-trim
+# Waveform Analyzer
+
+This project provides a simple web interface to load a local audio or video file and analyze its waveform. The analysis runs completely in the browser—no files are uploaded to any server.
+
+## Features
+
+- Load audio or video files from your computer.
+- Display a high-quality waveform using [WaveSurfer.js](https://wavesurfer.xyz/).
+- Detect peaks, valleys, transients, and estimate the noise floor.
+- Show visual indicators for these events on an analysis canvas.
+
+## Usage
+
+Open `web/index.html` in a modern browser. Then select an audio or video file using the file picker. The waveform will render along with graphical markers for the analysis results.
+
+No build step is required; all dependencies are loaded via CDN.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Audio/Video Waveform Analyzer</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- Wavesurfer.js CDN -->
+    <script src="https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.min.js"></script>
+</head>
+<body>
+    <h1>Waveform Analyzer</h1>
+    <input type="file" id="file-input" accept="audio/*,video/*">
+    <div id="waveform"></div>
+    <canvas id="analysis-canvas" width="800" height="200"></canvas>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,93 @@
+const fileInput = document.getElementById('file-input');
+let wavesurfer;
+
+fileInput.addEventListener('change', async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    if (wavesurfer) {
+        wavesurfer.destroy();
+    }
+
+    wavesurfer = WaveSurfer.create({
+        container: '#waveform',
+        waveColor: '#4a90e2',
+        progressColor: '#2d5fa8',
+        height: 128,
+        responsive: true
+    });
+
+    const url = URL.createObjectURL(file);
+    wavesurfer.load(url);
+
+    wavesurfer.on('ready', async () => {
+        const buffer = await wavesurfer.getDecodedData();
+        const analysis = analyzeBuffer(buffer);
+        drawAnalysis(analysis, buffer.duration);
+    });
+});
+
+function analyzeBuffer(buffer) {
+    const data = buffer.getChannelData(0); // use first channel
+    const sampleRate = buffer.sampleRate;
+    const windowSize = Math.floor(sampleRate / 100); // ~10ms windows
+    const amp = [];
+    for (let i = 0; i < data.length; i += windowSize) {
+        let sum = 0;
+        for (let j = i; j < i + windowSize && j < data.length; j++) {
+            sum += data[j] * data[j];
+        }
+        amp.push(Math.sqrt(sum / windowSize));
+    }
+
+    const noiseFloor = amp.reduce((a, b) => a + b, 0) / amp.length;
+
+    const peaks = [];
+    const valleys = [];
+    const transients = [];
+    for (let i = 1; i < amp.length - 1; i++) {
+        if (amp[i] > amp[i - 1] && amp[i] > amp[i + 1] && amp[i] > noiseFloor * 1.5) {
+            peaks.push({ index: i, value: amp[i] });
+        }
+        if (amp[i] < amp[i - 1] && amp[i] < amp[i + 1]) {
+            valleys.push({ index: i, value: amp[i] });
+        }
+        if (amp[i] - amp[i - 1] > noiseFloor) {
+            transients.push({ index: i, value: amp[i] });
+        }
+    }
+
+    return { amp, peaks, valleys, transients, noiseFloor };
+}
+
+function drawAnalysis(analysis, duration) {
+    const canvas = document.getElementById('analysis-canvas');
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const { peaks, valleys, transients, noiseFloor } = analysis;
+    const height = canvas.height;
+
+    ctx.strokeStyle = 'green';
+    const noiseY = height - noiseFloor * height;
+    ctx.beginPath();
+    ctx.moveTo(0, noiseY);
+    ctx.lineTo(canvas.width, noiseY);
+    ctx.stroke();
+
+    function drawLines(points, color) {
+        ctx.strokeStyle = color;
+        points.forEach(p => {
+            const time = (p.index / analysis.amp.length) * duration;
+            const x = (time / duration) * canvas.width;
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, height);
+            ctx.stroke();
+        });
+    }
+
+    drawLines(peaks, 'red');
+    drawLines(valleys, 'blue');
+    drawLines(transients, 'orange');
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,13 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+#waveform {
+    width: 800px;
+    height: 128px;
+    margin-top: 20px;
+}
+#analysis-canvas {
+    border: 1px solid #ccc;
+    margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- add a small static web app to load local audio/video files
- generate a waveform via WaveSurfer.js and analyze amplitude
- show peaks, valleys, transients and noise floor on a canvas
- document usage in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6843ad7ca3d4833289a655a36ff61eb6